### PR TITLE
Add parity-based reliability to the L0 for Astral

### DIFF
--- a/src/ctrl_unit/cluster_icache_ctrl.hjson
+++ b/src/ctrl_unit/cluster_icache_ctrl.hjson
@@ -19,7 +19,7 @@
     },
     { name: "NumL0Events",
       desc: "Number of L0 events",
-      default: "5"
+      default: "7"
     },
     { name: "NumL1Events",
       desc: "Number of L1 events",
@@ -27,7 +27,7 @@
     },
     { name: "NumAvailableCounters",
       desc: "Number of available counters",
-      default: "46" // NumL1Events + NumCores * NumL0Events
+      default: "62" // NumL1Events + NumCores * NumL0Events
     },
   ],
 

--- a/src/ctrl_unit/cluster_icache_ctrl_perfctr.hjson
+++ b/src/ctrl_unit/cluster_icache_ctrl_perfctr.hjson
@@ -19,7 +19,7 @@
     },
     { name: "NumL0Events",
       desc: "Number of L0 events",
-      default: "5" // Use performance counters for L0 events
+      default: "7" // Use performance counters for L0 events
     },
     { name: "NumL1Events",
       desc: "Number of L1 events",

--- a/src/ctrl_unit/cluster_icache_ctrl_perfctr_reg_pkg.sv
+++ b/src/ctrl_unit/cluster_icache_ctrl_perfctr_reg_pkg.sv
@@ -8,7 +8,7 @@ package cluster_icache_ctrl_perfctr_reg_pkg;
 
   // Param list
   parameter int NumCores = 8;
-  parameter int NumL0Events = 5;
+  parameter int NumL0Events = 7;
   parameter int NumL1Events = 6;
   parameter int NumAvailableCounters = 6;
 

--- a/src/ctrl_unit/cluster_icache_ctrl_reg_pkg.sv
+++ b/src/ctrl_unit/cluster_icache_ctrl_reg_pkg.sv
@@ -8,12 +8,12 @@ package cluster_icache_ctrl_reg_pkg;
 
   // Param list
   parameter int NumCores = 8;
-  parameter int NumL0Events = 5;
+  parameter int NumL0Events = 7;
   parameter int NumL1Events = 6;
-  parameter int NumAvailableCounters = 46;
+  parameter int NumAvailableCounters = 62;
 
   // Address widths within the block
-  parameter int BlockAw = 8;
+  parameter int BlockAw = 9;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -78,79 +78,95 @@ package cluster_icache_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    cluster_icache_ctrl_reg2hw_enable_reg_t enable; // [1489:1489]
-    cluster_icache_ctrl_reg2hw_flush_reg_t flush; // [1488:1487]
-    cluster_icache_ctrl_reg2hw_flush_l1_only_reg_t flush_l1_only; // [1486:1485]
-    cluster_icache_ctrl_reg2hw_sel_flush_icache_reg_t sel_flush_icache; // [1484:1476]
-    cluster_icache_ctrl_reg2hw_clear_counters_reg_t clear_counters; // [1475:1474]
-    cluster_icache_ctrl_reg2hw_enable_counters_reg_t enable_counters; // [1473:1473]
-    cluster_icache_ctrl_reg2hw_enable_prefetch_reg_t enable_prefetch; // [1472:1472]
-    cluster_icache_ctrl_reg2hw_counters_mreg_t [45:0] counters; // [1471:0]
+    cluster_icache_ctrl_reg2hw_enable_reg_t enable; // [2001:2001]
+    cluster_icache_ctrl_reg2hw_flush_reg_t flush; // [2000:1999]
+    cluster_icache_ctrl_reg2hw_flush_l1_only_reg_t flush_l1_only; // [1998:1997]
+    cluster_icache_ctrl_reg2hw_sel_flush_icache_reg_t sel_flush_icache; // [1996:1988]
+    cluster_icache_ctrl_reg2hw_clear_counters_reg_t clear_counters; // [1987:1986]
+    cluster_icache_ctrl_reg2hw_enable_counters_reg_t enable_counters; // [1985:1985]
+    cluster_icache_ctrl_reg2hw_enable_prefetch_reg_t enable_prefetch; // [1984:1984]
+    cluster_icache_ctrl_reg2hw_counters_mreg_t [61:0] counters; // [1983:0]
   } cluster_icache_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    cluster_icache_ctrl_hw2reg_flush_reg_t flush; // [1528:1528]
-    cluster_icache_ctrl_hw2reg_flush_l1_only_reg_t flush_l1_only; // [1527:1527]
-    cluster_icache_ctrl_hw2reg_sel_flush_icache_reg_t sel_flush_icache; // [1526:1519]
-    cluster_icache_ctrl_hw2reg_clear_counters_reg_t clear_counters; // [1518:1518]
-    cluster_icache_ctrl_hw2reg_counters_mreg_t [45:0] counters; // [1517:0]
+    cluster_icache_ctrl_hw2reg_flush_reg_t flush; // [2056:2056]
+    cluster_icache_ctrl_hw2reg_flush_l1_only_reg_t flush_l1_only; // [2055:2055]
+    cluster_icache_ctrl_hw2reg_sel_flush_icache_reg_t sel_flush_icache; // [2054:2047]
+    cluster_icache_ctrl_hw2reg_clear_counters_reg_t clear_counters; // [2046:2046]
+    cluster_icache_ctrl_hw2reg_counters_mreg_t [61:0] counters; // [2045:0]
   } cluster_icache_ctrl_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_OFFSET = 8'h 0;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_FLUSH_OFFSET = 8'h 4;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_FLUSH_L1_ONLY_OFFSET = 8'h 8;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_SEL_FLUSH_ICACHE_OFFSET = 8'h c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_CLEAR_COUNTERS_OFFSET = 8'h 10;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_COUNTERS_OFFSET = 8'h 14;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_PREFETCH_OFFSET = 8'h 1c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_0_OFFSET = 8'h 20;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_1_OFFSET = 8'h 24;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_2_OFFSET = 8'h 28;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_3_OFFSET = 8'h 2c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_4_OFFSET = 8'h 30;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_5_OFFSET = 8'h 34;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_6_OFFSET = 8'h 38;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_7_OFFSET = 8'h 3c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_8_OFFSET = 8'h 40;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_9_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_10_OFFSET = 8'h 48;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_11_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_12_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_13_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_14_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_15_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_16_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_17_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_18_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_19_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_20_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_21_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_22_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_23_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_24_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_25_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_26_OFFSET = 8'h 88;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_27_OFFSET = 8'h 8c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_28_OFFSET = 8'h 90;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_29_OFFSET = 8'h 94;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_30_OFFSET = 8'h 98;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_31_OFFSET = 8'h 9c;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_32_OFFSET = 8'h a0;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_33_OFFSET = 8'h a4;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_34_OFFSET = 8'h a8;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_35_OFFSET = 8'h ac;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_36_OFFSET = 8'h b0;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_37_OFFSET = 8'h b4;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_38_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_39_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_40_OFFSET = 8'h c0;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_41_OFFSET = 8'h c4;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_42_OFFSET = 8'h c8;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_43_OFFSET = 8'h cc;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_44_OFFSET = 8'h d0;
-  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_45_OFFSET = 8'h d4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_OFFSET = 9'h 0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_FLUSH_OFFSET = 9'h 4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_FLUSH_L1_ONLY_OFFSET = 9'h 8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_SEL_FLUSH_ICACHE_OFFSET = 9'h c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_CLEAR_COUNTERS_OFFSET = 9'h 10;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_COUNTERS_OFFSET = 9'h 14;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_ENABLE_PREFETCH_OFFSET = 9'h 1c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_0_OFFSET = 9'h 20;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_1_OFFSET = 9'h 24;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_2_OFFSET = 9'h 28;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_3_OFFSET = 9'h 2c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_4_OFFSET = 9'h 30;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_5_OFFSET = 9'h 34;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_6_OFFSET = 9'h 38;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_7_OFFSET = 9'h 3c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_8_OFFSET = 9'h 40;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_9_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_10_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_11_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_12_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_13_OFFSET = 9'h 54;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_14_OFFSET = 9'h 58;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_15_OFFSET = 9'h 5c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_16_OFFSET = 9'h 60;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_17_OFFSET = 9'h 64;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_18_OFFSET = 9'h 68;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_19_OFFSET = 9'h 6c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_20_OFFSET = 9'h 70;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_21_OFFSET = 9'h 74;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_22_OFFSET = 9'h 78;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_23_OFFSET = 9'h 7c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_24_OFFSET = 9'h 80;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_25_OFFSET = 9'h 84;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_26_OFFSET = 9'h 88;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_27_OFFSET = 9'h 8c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_28_OFFSET = 9'h 90;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_29_OFFSET = 9'h 94;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_30_OFFSET = 9'h 98;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_31_OFFSET = 9'h 9c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_32_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_33_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_34_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_35_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_36_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_37_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_38_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_39_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_40_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_41_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_42_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_43_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_44_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_45_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_46_OFFSET = 9'h d8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_47_OFFSET = 9'h dc;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_48_OFFSET = 9'h e0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_49_OFFSET = 9'h e4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_50_OFFSET = 9'h e8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_51_OFFSET = 9'h ec;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_52_OFFSET = 9'h f0;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_53_OFFSET = 9'h f4;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_54_OFFSET = 9'h f8;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_55_OFFSET = 9'h fc;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_56_OFFSET = 9'h 100;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_57_OFFSET = 9'h 104;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_58_OFFSET = 9'h 108;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_59_OFFSET = 9'h 10c;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_60_OFFSET = 9'h 110;
+  parameter logic [BlockAw-1:0] CLUSTER_ICACHE_CTRL_COUNTERS_61_OFFSET = 9'h 114;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] CLUSTER_ICACHE_CTRL_FLUSH_RESVAL = 1'h 0;
@@ -216,11 +232,27 @@ package cluster_icache_ctrl_reg_pkg;
     CLUSTER_ICACHE_CTRL_COUNTERS_42,
     CLUSTER_ICACHE_CTRL_COUNTERS_43,
     CLUSTER_ICACHE_CTRL_COUNTERS_44,
-    CLUSTER_ICACHE_CTRL_COUNTERS_45
+    CLUSTER_ICACHE_CTRL_COUNTERS_45,
+    CLUSTER_ICACHE_CTRL_COUNTERS_46,
+    CLUSTER_ICACHE_CTRL_COUNTERS_47,
+    CLUSTER_ICACHE_CTRL_COUNTERS_48,
+    CLUSTER_ICACHE_CTRL_COUNTERS_49,
+    CLUSTER_ICACHE_CTRL_COUNTERS_50,
+    CLUSTER_ICACHE_CTRL_COUNTERS_51,
+    CLUSTER_ICACHE_CTRL_COUNTERS_52,
+    CLUSTER_ICACHE_CTRL_COUNTERS_53,
+    CLUSTER_ICACHE_CTRL_COUNTERS_54,
+    CLUSTER_ICACHE_CTRL_COUNTERS_55,
+    CLUSTER_ICACHE_CTRL_COUNTERS_56,
+    CLUSTER_ICACHE_CTRL_COUNTERS_57,
+    CLUSTER_ICACHE_CTRL_COUNTERS_58,
+    CLUSTER_ICACHE_CTRL_COUNTERS_59,
+    CLUSTER_ICACHE_CTRL_COUNTERS_60,
+    CLUSTER_ICACHE_CTRL_COUNTERS_61
   } cluster_icache_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CLUSTER_ICACHE_CTRL_PERMIT [53] = '{
+  parameter logic [3:0] CLUSTER_ICACHE_CTRL_PERMIT [69] = '{
     4'b 0001, // index[ 0] CLUSTER_ICACHE_CTRL_ENABLE
     4'b 0001, // index[ 1] CLUSTER_ICACHE_CTRL_FLUSH
     4'b 0001, // index[ 2] CLUSTER_ICACHE_CTRL_FLUSH_L1_ONLY
@@ -273,7 +305,23 @@ package cluster_icache_ctrl_reg_pkg;
     4'b 1111, // index[49] CLUSTER_ICACHE_CTRL_COUNTERS_42
     4'b 1111, // index[50] CLUSTER_ICACHE_CTRL_COUNTERS_43
     4'b 1111, // index[51] CLUSTER_ICACHE_CTRL_COUNTERS_44
-    4'b 1111  // index[52] CLUSTER_ICACHE_CTRL_COUNTERS_45
+    4'b 1111, // index[52] CLUSTER_ICACHE_CTRL_COUNTERS_45
+    4'b 1111, // index[53] CLUSTER_ICACHE_CTRL_COUNTERS_46
+    4'b 1111, // index[54] CLUSTER_ICACHE_CTRL_COUNTERS_47
+    4'b 1111, // index[55] CLUSTER_ICACHE_CTRL_COUNTERS_48
+    4'b 1111, // index[56] CLUSTER_ICACHE_CTRL_COUNTERS_49
+    4'b 1111, // index[57] CLUSTER_ICACHE_CTRL_COUNTERS_50
+    4'b 1111, // index[58] CLUSTER_ICACHE_CTRL_COUNTERS_51
+    4'b 1111, // index[59] CLUSTER_ICACHE_CTRL_COUNTERS_52
+    4'b 1111, // index[60] CLUSTER_ICACHE_CTRL_COUNTERS_53
+    4'b 1111, // index[61] CLUSTER_ICACHE_CTRL_COUNTERS_54
+    4'b 1111, // index[62] CLUSTER_ICACHE_CTRL_COUNTERS_55
+    4'b 1111, // index[63] CLUSTER_ICACHE_CTRL_COUNTERS_56
+    4'b 1111, // index[64] CLUSTER_ICACHE_CTRL_COUNTERS_57
+    4'b 1111, // index[65] CLUSTER_ICACHE_CTRL_COUNTERS_58
+    4'b 1111, // index[66] CLUSTER_ICACHE_CTRL_COUNTERS_59
+    4'b 1111, // index[67] CLUSTER_ICACHE_CTRL_COUNTERS_60
+    4'b 1111  // index[68] CLUSTER_ICACHE_CTRL_COUNTERS_61
   };
 
 endpackage

--- a/src/ctrl_unit/cluster_icache_ctrl_reg_top.sv
+++ b/src/ctrl_unit/cluster_icache_ctrl_reg_top.sv
@@ -10,7 +10,7 @@
 module cluster_icache_ctrl_reg_top #(
   parameter type reg_req_t = logic,
   parameter type reg_rsp_t = logic,
-  parameter int AW = 8
+  parameter int AW = 9
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -231,6 +231,54 @@ module cluster_icache_ctrl_reg_top #(
   logic [31:0] counters_45_qs;
   logic [31:0] counters_45_wd;
   logic counters_45_we;
+  logic [31:0] counters_46_qs;
+  logic [31:0] counters_46_wd;
+  logic counters_46_we;
+  logic [31:0] counters_47_qs;
+  logic [31:0] counters_47_wd;
+  logic counters_47_we;
+  logic [31:0] counters_48_qs;
+  logic [31:0] counters_48_wd;
+  logic counters_48_we;
+  logic [31:0] counters_49_qs;
+  logic [31:0] counters_49_wd;
+  logic counters_49_we;
+  logic [31:0] counters_50_qs;
+  logic [31:0] counters_50_wd;
+  logic counters_50_we;
+  logic [31:0] counters_51_qs;
+  logic [31:0] counters_51_wd;
+  logic counters_51_we;
+  logic [31:0] counters_52_qs;
+  logic [31:0] counters_52_wd;
+  logic counters_52_we;
+  logic [31:0] counters_53_qs;
+  logic [31:0] counters_53_wd;
+  logic counters_53_we;
+  logic [31:0] counters_54_qs;
+  logic [31:0] counters_54_wd;
+  logic counters_54_we;
+  logic [31:0] counters_55_qs;
+  logic [31:0] counters_55_wd;
+  logic counters_55_we;
+  logic [31:0] counters_56_qs;
+  logic [31:0] counters_56_wd;
+  logic counters_56_we;
+  logic [31:0] counters_57_qs;
+  logic [31:0] counters_57_wd;
+  logic counters_57_we;
+  logic [31:0] counters_58_qs;
+  logic [31:0] counters_58_wd;
+  logic counters_58_we;
+  logic [31:0] counters_59_qs;
+  logic [31:0] counters_59_wd;
+  logic counters_59_we;
+  logic [31:0] counters_60_qs;
+  logic [31:0] counters_60_wd;
+  logic counters_60_we;
+  logic [31:0] counters_61_qs;
+  logic [31:0] counters_61_wd;
+  logic counters_61_we;
 
   // Register instances
   // R[enable]: V(False)
@@ -1621,10 +1669,442 @@ module cluster_icache_ctrl_reg_top #(
     .qs     (counters_45_qs)
   );
 
+  // Subregister 46 of Multireg counters
+  // R[counters_46]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_46 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_46_we),
+    .wd     (counters_46_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[46].de),
+    .d      (hw2reg.counters[46].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[46].q ),
+
+    // to register interface (read)
+    .qs     (counters_46_qs)
+  );
+
+  // Subregister 47 of Multireg counters
+  // R[counters_47]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_47 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_47_we),
+    .wd     (counters_47_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[47].de),
+    .d      (hw2reg.counters[47].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[47].q ),
+
+    // to register interface (read)
+    .qs     (counters_47_qs)
+  );
+
+  // Subregister 48 of Multireg counters
+  // R[counters_48]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_48 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_48_we),
+    .wd     (counters_48_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[48].de),
+    .d      (hw2reg.counters[48].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[48].q ),
+
+    // to register interface (read)
+    .qs     (counters_48_qs)
+  );
+
+  // Subregister 49 of Multireg counters
+  // R[counters_49]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_49 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_49_we),
+    .wd     (counters_49_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[49].de),
+    .d      (hw2reg.counters[49].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[49].q ),
+
+    // to register interface (read)
+    .qs     (counters_49_qs)
+  );
+
+  // Subregister 50 of Multireg counters
+  // R[counters_50]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_50 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_50_we),
+    .wd     (counters_50_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[50].de),
+    .d      (hw2reg.counters[50].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[50].q ),
+
+    // to register interface (read)
+    .qs     (counters_50_qs)
+  );
+
+  // Subregister 51 of Multireg counters
+  // R[counters_51]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_51 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_51_we),
+    .wd     (counters_51_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[51].de),
+    .d      (hw2reg.counters[51].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[51].q ),
+
+    // to register interface (read)
+    .qs     (counters_51_qs)
+  );
+
+  // Subregister 52 of Multireg counters
+  // R[counters_52]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_52 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_52_we),
+    .wd     (counters_52_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[52].de),
+    .d      (hw2reg.counters[52].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[52].q ),
+
+    // to register interface (read)
+    .qs     (counters_52_qs)
+  );
+
+  // Subregister 53 of Multireg counters
+  // R[counters_53]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_53 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_53_we),
+    .wd     (counters_53_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[53].de),
+    .d      (hw2reg.counters[53].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[53].q ),
+
+    // to register interface (read)
+    .qs     (counters_53_qs)
+  );
+
+  // Subregister 54 of Multireg counters
+  // R[counters_54]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_54 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_54_we),
+    .wd     (counters_54_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[54].de),
+    .d      (hw2reg.counters[54].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[54].q ),
+
+    // to register interface (read)
+    .qs     (counters_54_qs)
+  );
+
+  // Subregister 55 of Multireg counters
+  // R[counters_55]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_55 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_55_we),
+    .wd     (counters_55_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[55].de),
+    .d      (hw2reg.counters[55].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[55].q ),
+
+    // to register interface (read)
+    .qs     (counters_55_qs)
+  );
+
+  // Subregister 56 of Multireg counters
+  // R[counters_56]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_56 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_56_we),
+    .wd     (counters_56_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[56].de),
+    .d      (hw2reg.counters[56].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[56].q ),
+
+    // to register interface (read)
+    .qs     (counters_56_qs)
+  );
+
+  // Subregister 57 of Multireg counters
+  // R[counters_57]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_57 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_57_we),
+    .wd     (counters_57_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[57].de),
+    .d      (hw2reg.counters[57].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[57].q ),
+
+    // to register interface (read)
+    .qs     (counters_57_qs)
+  );
+
+  // Subregister 58 of Multireg counters
+  // R[counters_58]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_58 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_58_we),
+    .wd     (counters_58_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[58].de),
+    .d      (hw2reg.counters[58].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[58].q ),
+
+    // to register interface (read)
+    .qs     (counters_58_qs)
+  );
+
+  // Subregister 59 of Multireg counters
+  // R[counters_59]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_59 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_59_we),
+    .wd     (counters_59_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[59].de),
+    .d      (hw2reg.counters[59].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[59].q ),
+
+    // to register interface (read)
+    .qs     (counters_59_qs)
+  );
+
+  // Subregister 60 of Multireg counters
+  // R[counters_60]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_60 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_60_we),
+    .wd     (counters_60_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[60].de),
+    .d      (hw2reg.counters[60].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[60].q ),
+
+    // to register interface (read)
+    .qs     (counters_60_qs)
+  );
+
+  // Subregister 61 of Multireg counters
+  // R[counters_61]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("W0C"),
+    .RESVAL  (32'h0)
+  ) u_counters_61 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (counters_61_we),
+    .wd     (counters_61_wd),
+
+    // from internal hardware
+    .de     (hw2reg.counters[61].de),
+    .d      (hw2reg.counters[61].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.counters[61].q ),
+
+    // to register interface (read)
+    .qs     (counters_61_qs)
+  );
 
 
 
-  logic [52:0] addr_hit;
+
+  logic [68:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CLUSTER_ICACHE_CTRL_ENABLE_OFFSET);
@@ -1680,6 +2160,22 @@ module cluster_icache_ctrl_reg_top #(
     addr_hit[50] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_43_OFFSET);
     addr_hit[51] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_44_OFFSET);
     addr_hit[52] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_45_OFFSET);
+    addr_hit[53] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_46_OFFSET);
+    addr_hit[54] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_47_OFFSET);
+    addr_hit[55] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_48_OFFSET);
+    addr_hit[56] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_49_OFFSET);
+    addr_hit[57] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_50_OFFSET);
+    addr_hit[58] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_51_OFFSET);
+    addr_hit[59] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_52_OFFSET);
+    addr_hit[60] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_53_OFFSET);
+    addr_hit[61] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_54_OFFSET);
+    addr_hit[62] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_55_OFFSET);
+    addr_hit[63] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_56_OFFSET);
+    addr_hit[64] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_57_OFFSET);
+    addr_hit[65] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_58_OFFSET);
+    addr_hit[66] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_59_OFFSET);
+    addr_hit[67] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_60_OFFSET);
+    addr_hit[68] = (reg_addr == CLUSTER_ICACHE_CTRL_COUNTERS_61_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1739,7 +2235,23 @@ module cluster_icache_ctrl_reg_top #(
                (addr_hit[49] & (|(CLUSTER_ICACHE_CTRL_PERMIT[49] & ~reg_be))) |
                (addr_hit[50] & (|(CLUSTER_ICACHE_CTRL_PERMIT[50] & ~reg_be))) |
                (addr_hit[51] & (|(CLUSTER_ICACHE_CTRL_PERMIT[51] & ~reg_be))) |
-               (addr_hit[52] & (|(CLUSTER_ICACHE_CTRL_PERMIT[52] & ~reg_be)))));
+               (addr_hit[52] & (|(CLUSTER_ICACHE_CTRL_PERMIT[52] & ~reg_be))) |
+               (addr_hit[53] & (|(CLUSTER_ICACHE_CTRL_PERMIT[53] & ~reg_be))) |
+               (addr_hit[54] & (|(CLUSTER_ICACHE_CTRL_PERMIT[54] & ~reg_be))) |
+               (addr_hit[55] & (|(CLUSTER_ICACHE_CTRL_PERMIT[55] & ~reg_be))) |
+               (addr_hit[56] & (|(CLUSTER_ICACHE_CTRL_PERMIT[56] & ~reg_be))) |
+               (addr_hit[57] & (|(CLUSTER_ICACHE_CTRL_PERMIT[57] & ~reg_be))) |
+               (addr_hit[58] & (|(CLUSTER_ICACHE_CTRL_PERMIT[58] & ~reg_be))) |
+               (addr_hit[59] & (|(CLUSTER_ICACHE_CTRL_PERMIT[59] & ~reg_be))) |
+               (addr_hit[60] & (|(CLUSTER_ICACHE_CTRL_PERMIT[60] & ~reg_be))) |
+               (addr_hit[61] & (|(CLUSTER_ICACHE_CTRL_PERMIT[61] & ~reg_be))) |
+               (addr_hit[62] & (|(CLUSTER_ICACHE_CTRL_PERMIT[62] & ~reg_be))) |
+               (addr_hit[63] & (|(CLUSTER_ICACHE_CTRL_PERMIT[63] & ~reg_be))) |
+               (addr_hit[64] & (|(CLUSTER_ICACHE_CTRL_PERMIT[64] & ~reg_be))) |
+               (addr_hit[65] & (|(CLUSTER_ICACHE_CTRL_PERMIT[65] & ~reg_be))) |
+               (addr_hit[66] & (|(CLUSTER_ICACHE_CTRL_PERMIT[66] & ~reg_be))) |
+               (addr_hit[67] & (|(CLUSTER_ICACHE_CTRL_PERMIT[67] & ~reg_be))) |
+               (addr_hit[68] & (|(CLUSTER_ICACHE_CTRL_PERMIT[68] & ~reg_be)))));
   end
 
   assign enable_we = addr_hit[0] & reg_we & !reg_error;
@@ -1904,6 +2416,54 @@ module cluster_icache_ctrl_reg_top #(
 
   assign counters_45_we = addr_hit[52] & reg_we & !reg_error;
   assign counters_45_wd = reg_wdata[31:0];
+
+  assign counters_46_we = addr_hit[53] & reg_we & !reg_error;
+  assign counters_46_wd = reg_wdata[31:0];
+
+  assign counters_47_we = addr_hit[54] & reg_we & !reg_error;
+  assign counters_47_wd = reg_wdata[31:0];
+
+  assign counters_48_we = addr_hit[55] & reg_we & !reg_error;
+  assign counters_48_wd = reg_wdata[31:0];
+
+  assign counters_49_we = addr_hit[56] & reg_we & !reg_error;
+  assign counters_49_wd = reg_wdata[31:0];
+
+  assign counters_50_we = addr_hit[57] & reg_we & !reg_error;
+  assign counters_50_wd = reg_wdata[31:0];
+
+  assign counters_51_we = addr_hit[58] & reg_we & !reg_error;
+  assign counters_51_wd = reg_wdata[31:0];
+
+  assign counters_52_we = addr_hit[59] & reg_we & !reg_error;
+  assign counters_52_wd = reg_wdata[31:0];
+
+  assign counters_53_we = addr_hit[60] & reg_we & !reg_error;
+  assign counters_53_wd = reg_wdata[31:0];
+
+  assign counters_54_we = addr_hit[61] & reg_we & !reg_error;
+  assign counters_54_wd = reg_wdata[31:0];
+
+  assign counters_55_we = addr_hit[62] & reg_we & !reg_error;
+  assign counters_55_wd = reg_wdata[31:0];
+
+  assign counters_56_we = addr_hit[63] & reg_we & !reg_error;
+  assign counters_56_wd = reg_wdata[31:0];
+
+  assign counters_57_we = addr_hit[64] & reg_we & !reg_error;
+  assign counters_57_wd = reg_wdata[31:0];
+
+  assign counters_58_we = addr_hit[65] & reg_we & !reg_error;
+  assign counters_58_wd = reg_wdata[31:0];
+
+  assign counters_59_we = addr_hit[66] & reg_we & !reg_error;
+  assign counters_59_wd = reg_wdata[31:0];
+
+  assign counters_60_we = addr_hit[67] & reg_we & !reg_error;
+  assign counters_60_wd = reg_wdata[31:0];
+
+  assign counters_61_we = addr_hit[68] & reg_we & !reg_error;
+  assign counters_61_wd = reg_wdata[31:0];
 
   // Read data return
   always_comb begin
@@ -2121,6 +2681,70 @@ module cluster_icache_ctrl_reg_top #(
         reg_rdata_next[31:0] = counters_45_qs;
       end
 
+      addr_hit[53]: begin
+        reg_rdata_next[31:0] = counters_46_qs;
+      end
+
+      addr_hit[54]: begin
+        reg_rdata_next[31:0] = counters_47_qs;
+      end
+
+      addr_hit[55]: begin
+        reg_rdata_next[31:0] = counters_48_qs;
+      end
+
+      addr_hit[56]: begin
+        reg_rdata_next[31:0] = counters_49_qs;
+      end
+
+      addr_hit[57]: begin
+        reg_rdata_next[31:0] = counters_50_qs;
+      end
+
+      addr_hit[58]: begin
+        reg_rdata_next[31:0] = counters_51_qs;
+      end
+
+      addr_hit[59]: begin
+        reg_rdata_next[31:0] = counters_52_qs;
+      end
+
+      addr_hit[60]: begin
+        reg_rdata_next[31:0] = counters_53_qs;
+      end
+
+      addr_hit[61]: begin
+        reg_rdata_next[31:0] = counters_54_qs;
+      end
+
+      addr_hit[62]: begin
+        reg_rdata_next[31:0] = counters_55_qs;
+      end
+
+      addr_hit[63]: begin
+        reg_rdata_next[31:0] = counters_56_qs;
+      end
+
+      addr_hit[64]: begin
+        reg_rdata_next[31:0] = counters_57_qs;
+      end
+
+      addr_hit[65]: begin
+        reg_rdata_next[31:0] = counters_58_qs;
+      end
+
+      addr_hit[66]: begin
+        reg_rdata_next[31:0] = counters_59_qs;
+      end
+
+      addr_hit[67]: begin
+        reg_rdata_next[31:0] = counters_60_qs;
+      end
+
+      addr_hit[68]: begin
+        reg_rdata_next[31:0] = counters_61_qs;
+      end
+
       default: begin
         reg_rdata_next = '1;
       end
@@ -2143,7 +2767,7 @@ endmodule
 
 module cluster_icache_ctrl_reg_top_intf
 #(
-  parameter int AW = 8,
+  parameter int AW = 9,
   localparam int DW = 32
 ) (
   input logic clk_i,

--- a/src/ctrl_unit/cluster_icache_ctrl_unit.sv
+++ b/src/ctrl_unit/cluster_icache_ctrl_unit.sv
@@ -78,6 +78,10 @@ module cluster_icache_ctrl_unit import snitch_icache_pkg::*; #(
                                                          l0_events_i[i].l0_double_hit;
       counters_reg[NumL1Events + i*NumL0Events + 4].de = reg2hw.enable_counters.q &
                                                          l0_events_i[i].l0_stall;
+      counters_reg[NumL1Events + i*NumL0Events + 5].de = reg2hw.enable_counters.q &
+                                                         l0_events_i[i].l0_tag_parity_error;
+      counters_reg[NumL1Events + i*NumL0Events + 6].de = reg2hw.enable_counters.q &
+                                                         l0_events_i[i].l0_data_parity_error;
     end
 
     // Clear on global clear signal

--- a/src/pulp_icache_wrap.sv
+++ b/src/pulp_icache_wrap.sv
@@ -36,6 +36,8 @@ module pulp_icache_wrap #(
   parameter int SET_COUNT = 1,
   /// Error detection
   parameter int unsigned L1DataParityWidth = 0,
+  /// Error detection L0
+  parameter int unsigned L0DataParityWidth = L1DataParityWidth,
   /// Fetch interface address width. Same as FILL_AW; >= 1.
   parameter int FetchAddrWidth = -1,
   /// Fetch interface data width. Power of two; >= 8.
@@ -206,6 +208,7 @@ module pulp_icache_wrap #(
     .FILL_DW            ( AxiDataWidth    ),
     .FETCH_PRIORITY     ( 1               ),
     .MERGE_FETCHES      ( 1               ),
+    .L0_DATA_PARITY_BITS( L0DataParityWidth ),
     .L1_DATA_PARITY_BITS( L1DataParityWidth ),
     .L1_TAG_SCM         ( 1               ),
     .SERIAL_LOOKUP      ( 1               ),

--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -30,6 +30,8 @@ module snitch_icache import snitch_icache_pkg::*; #(
   parameter bit FETCH_PRIORITY = 1'b0,
   /// Merge L0-L1 fetches if requesting the same address
   parameter bit MERGE_FETCHES = 1'b0,
+  /// Extra parity bits to add to a line for L0 reliability.
+  parameter int unsigned L0_DATA_PARITY_BITS = 0,
   /// Extra parity bits to add to a line for L1 reliability.
   parameter int unsigned L1_DATA_PARITY_BITS = 0,
   /// Serialize the L1 lookup (parallel tag/data lookup by default)
@@ -97,6 +99,7 @@ module snitch_icache import snitch_icache_pkg::*; #(
     FETCH_DW:           FETCH_DW,
     FILL_AW:            FILL_AW,
     FILL_DW:            FILL_DW,
+    L0_DATA_PARITY_BITS: L0_DATA_PARITY_BITS,
     L1_DATA_PARITY_BITS: L1_DATA_PARITY_BITS,
     L1_TAG_SCM:         L1_TAG_SCM,
     EARLY_LATCH:        EARLY_LATCH,

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -156,11 +156,15 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
         .clk_o     (clk_vld         )
       );
       // Data Array
+      /* verilator lint_off NOLATCH */
+      /* verilator lint_off COMBDLY */
       always_latch begin
         if (clk_vld) begin
           data[i] <= out_rsp_data_i;
         end
       end
+      /* verilator lint_on COMBDLY */
+      /* verilator lint_on NOLATCH */
     end else begin : gen_ff
       `FFLNR(data[i], out_rsp_data_i, validate_strb[i], clk_i)
     end

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -38,16 +38,18 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
   output logic                      out_rsp_ready_o
 );
 
+  localparam int unsigned TagParity = (CFG.L0_DATA_PARITY_BITS > 0) ? 1 : 0;
+
   typedef logic [CFG.FETCH_AW-1:0] addr_t;
   typedef struct packed {
-    logic [CFG.L0_TAG_WIDTH-1:0] tag;
-    logic                        vld;
+    logic [CFG.L0_TAG_WIDTH+TagParity-1:0] tag;
+    logic                                  vld;
   } tag_t;
 
   logic [CFG.L0_TAG_WIDTH-1:0] addr_tag, addr_tag_prefetch;
 
   tag_t [CFG.L0_LINE_COUNT-1:0] tag;
-  logic [CFG.L0_LINE_COUNT-1:0][CFG.LINE_WIDTH-1:0] data;
+  logic [CFG.L0_LINE_COUNT-1:0][CFG.LINE_WIDTH+CFG.L0_DATA_PARITY_BITS-1:0] data;
 
   logic [CFG.L0_LINE_COUNT-1:0] hit, hit_early, hit_prefetch;
   logic hit_early_is_onehot;
@@ -84,6 +86,9 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
 
   logic evict_because_miss, evict_because_prefetch;
 
+  logic data_parity_error;
+  logic [CFG.L0_LINE_COUNT-1:0] tag_parity_error_vect;
+
   typedef struct packed {
     logic                    is_prefetch;
     logic [CFG.FETCH_AW-1:0] addr;
@@ -104,22 +109,56 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
   // ------------
   // Tag Compare
   // ------------
-  for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_cmp_fetch
-    assign hit_early[i] = tag[i].vld &
-      (tag[i].tag[CFG.L0_EARLY_TAG_WIDTH-1:0] == addr_tag[CFG.L0_EARLY_TAG_WIDTH-1:0]);
-    // The two signals calculate the same.
-    if (CFG.L0_TAG_WIDTH == CFG.L0_EARLY_TAG_WIDTH) begin : gen_hit_assign
-      assign hit[i] = hit_early[i];
-    // Compare the rest of the tag.
-    end else begin : gen_hit
-      assign hit[i] = hit_early[i] &
-        (tag[i].tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]
-          == addr_tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]);
+
+  if (CFG.L0_DATA_PARITY_BITS > 0) begin : gen_tag_cmp_reliable
+
+    // For every line, compute the current parity bit
+    logic [CFG.L0_LINE_COUNT-1:0] exp_tag_parity;
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_exp_tag_parity
+      assign exp_tag_parity[i] = ~^tag[i].tag[CFG.L0_TAG_WIDTH-1:0];
     end
-    assign hit_prefetch[i] = tag[i].vld & (tag[i].tag == addr_tag_prefetch);
+
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_cmp_fetch
+      // Compute a parity error vector comparing the expected parity bit and the current one.
+      assign tag_parity_error_vect[i] = (exp_tag_parity[i] != tag[i].tag[CFG.L0_TAG_WIDTH]) &&
+                                        tag[i].vld;
+      assign hit_early[i] = tag[i].vld &
+        (tag[i].tag[CFG.L0_EARLY_TAG_WIDTH-1:0] == addr_tag[CFG.L0_EARLY_TAG_WIDTH-1:0]);
+      // The two signals calculate the same.
+      if (CFG.L0_TAG_WIDTH == CFG.L0_EARLY_TAG_WIDTH) begin : gen_hit_assign
+        assign hit[i] = hit_early[i] & !tag_parity_error_vect[i];
+      // Compare the rest of the tag and corresponding parity error vector.
+      end else begin : gen_hit
+        assign hit[i] = hit_early[i] &
+          (tag[i].tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]
+            == addr_tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]) & !tag_parity_error_vect[i];
+      end
+      assign hit_prefetch[i] = tag[i].vld & (tag[i].tag[CFG.L0_TAG_WIDTH-1:0] == addr_tag_prefetch);
+    end
+
+    assign hit_any = |hit && !data_parity_error;
+  end else begin : gen_tag_cmp_standard
+
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_cmp_fetch
+      assign hit_early[i] = tag[i].vld &
+        (tag[i].tag[CFG.L0_EARLY_TAG_WIDTH-1:0] == addr_tag[CFG.L0_EARLY_TAG_WIDTH-1:0]);
+      // The two signals calculate the same.
+      if (CFG.L0_TAG_WIDTH == CFG.L0_EARLY_TAG_WIDTH) begin : gen_hit_assign
+        assign hit[i] = hit_early[i];
+      // Compare the rest of the tag.
+      end else begin : gen_hit
+        assign hit[i] = hit_early[i] &
+          (tag[i].tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]
+            == addr_tag[CFG.L0_TAG_WIDTH-1:CFG.L0_EARLY_TAG_WIDTH]);
+      end
+      assign hit_prefetch[i] = tag[i].vld & (tag[i].tag == addr_tag_prefetch);
+    end
+
+    assign hit_any = |hit;
+
+    assign tag_parity_error_vect = '0;
   end
 
-  assign hit_any = |hit;
   assign hit_prefetch_any = |hit_prefetch;
   assign miss = ~hit_any & in_valid_i & ~pending_refill_q;
 
@@ -129,44 +168,102 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
     .clk_o (clk_inv)
   );
 
-  for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_array
-    // Tag Array
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        tag[i].vld <= 0;
-        tag[i].tag <= 0;
-      end else begin
-        if (evict_strb[i]) begin
-          tag[i].vld <= 1'b0;
-          tag[i].tag <= evict_because_prefetch ? addr_tag_prefetch : addr_tag;
-        end else if (validate_strb[i]) begin
-          tag[i].vld <= 1'b1;
-        end
-        if (flush_strb[i]) begin
-          tag[i].vld <= 1'b0;
-        end
-      end
+  localparam int unsigned LineParitySplit = CFG.LINE_WIDTH/CFG.L0_DATA_PARITY_BITS;
+  if (CFG.L0_DATA_PARITY_BITS > 0) begin : gen_tag_array_reliable
+
+    logic [CFG.L0_DATA_PARITY_BITS-1:0] data_parity;
+    // For every block of the configured block size, compute the parity bit
+    for (genvar i = 0; i < CFG.L0_DATA_PARITY_BITS; i++) begin : gen_data_parity
+      assign data_parity[i] =
+        ~^out_rsp_data_i[CFG.LINE_WIDTH - LineParitySplit*i-1 -: LineParitySplit];
     end
-    if (CFG.EARLY_LATCH) begin : gen_latch
-      logic clk_vld;
-      tc_clk_gating i_clk_gate (
-        .clk_i     (clk_inv         ),
-        .en_i      (validate_strb[i]),
-        .test_en_i (1'b0            ),
-        .clk_o     (clk_vld         )
-      );
-      // Data Array
-      /* verilator lint_off NOLATCH */
-      /* verilator lint_off COMBDLY */
-      always_latch begin
-        if (clk_vld) begin
-          data[i] <= out_rsp_data_i;
+
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_array
+      // Compute parity bits
+      always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (!rst_ni) begin
+          tag[i].vld <= 0;
+          tag[i].tag <= 0;
+        end else begin
+          if (evict_strb[i]) begin
+            tag[i].vld <= 1'b0;
+            tag[i].tag <= evict_because_prefetch ?
+                          {~^addr_tag_prefetch, addr_tag_prefetch} :
+                          {~^addr_tag, addr_tag};
+          end else if (validate_strb[i]) begin
+            tag[i].vld <= 1'b1;
+          end
+          if (flush_strb[i]) begin
+            tag[i].vld <= 1'b0;
+          end
         end
       end
-      /* verilator lint_on COMBDLY */
-      /* verilator lint_on NOLATCH */
-    end else begin : gen_ff
-      `FFLNR(data[i], out_rsp_data_i, validate_strb[i], clk_i)
+      if (CFG.EARLY_LATCH) begin : gen_latch
+        logic clk_vld;
+        tc_clk_gating i_clk_gate (
+          .clk_i     (clk_inv         ),
+          .en_i      (validate_strb[i]),
+          .test_en_i (1'b0            ),
+          .clk_o     (clk_vld         )
+        );
+        // Data Array
+        // Store both the parity and the data
+        /* verilator lint_off NOLATCH */
+        /* verilator lint_off COMBDLY */
+        always_latch begin
+          if (clk_vld) begin
+            data[i] <= {data_parity, out_rsp_data_i};
+          end
+        end
+        /* verilator lint_on COMBDLY */
+        /* verilator lint_on NOLATCH */
+      end else begin : gen_ff
+        `FFLNR(data[i], {data_parity, out_rsp_data_i}, validate_strb[i], clk_i)
+      end
+
+    end
+
+  end else begin : gen_tag_array_standard
+
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_array
+      // Tag Array
+      always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (!rst_ni) begin
+          tag[i].vld <= 0;
+          tag[i].tag <= 0;
+        end else begin
+          if (evict_strb[i]) begin
+            tag[i].vld <= 1'b0;
+            tag[i].tag <= evict_because_prefetch ? addr_tag_prefetch : addr_tag;
+          end else if (validate_strb[i]) begin
+            tag[i].vld <= 1'b1;
+          end
+          if (flush_strb[i]) begin
+            tag[i].vld <= 1'b0;
+          end
+        end
+      end
+      if (CFG.EARLY_LATCH) begin : gen_latch
+        logic clk_vld;
+        tc_clk_gating i_clk_gate (
+          .clk_i     (clk_inv         ),
+          .en_i      (validate_strb[i]),
+          .test_en_i (1'b0            ),
+          .clk_o     (clk_vld         )
+        );
+        // Data Array
+        /* verilator lint_off NOLATCH */
+        /* verilator lint_off COMBDLY */
+        always_latch begin
+          if (clk_vld) begin
+            data[i] <= out_rsp_data_i;
+          end
+        end
+        /* verilator lint_on COMBDLY */
+        /* verilator lint_on NOLATCH */
+      end else begin : gen_ff
+        `FFLNR(data[i], out_rsp_data_i, validate_strb[i], clk_i)
+      end
     end
   end
 
@@ -174,6 +271,29 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
   // HIT
   // ----
   // we hit in the cache and there was a unique hit.
+
+  logic [CFG.L0_LINE_COUNT-1:0] data_parity_error_vect;
+
+  if (CFG.L0_DATA_PARITY_BITS > 0) begin : gen_data_parity_error
+    logic [CFG.L0_LINE_COUNT-1:0][CFG.L0_DATA_PARITY_BITS-1:0] exp_data_parity;
+    // For every line, we compute the expected parity for every block
+    // Then we determine which lines are faulty
+    for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_data_parity_error_vect
+      for (genvar j = 0; j < CFG.L0_DATA_PARITY_BITS; j++) begin : gen_exp_data_parity
+        assign exp_data_parity[i][j] =
+          ~^data[i][CFG.LINE_WIDTH - LineParitySplit*j-1 -: LineParitySplit];
+      end
+      assign data_parity_error_vect[i] =
+        (exp_data_parity[i] != data[i][CFG.LINE_WIDTH+:CFG.L0_DATA_PARITY_BITS]) && tag[i].vld;
+    end
+    // Check whether the currently selected data has an error
+    assign data_parity_error =
+      data_parity_error_vect >> in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN];
+  end else begin : gen_data_parity_norel
+    assign data_parity_error_vect = '0;
+    assign data_parity_error = '0;
+  end
+
   assign in_ready_o = hit_any;
 
   logic [CFG.LINE_WIDTH-1:0] ins_data;
@@ -252,8 +372,22 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
       // but didn't hit in the final comparison.
       flush_strb = ~hit & hit_early;
     end
+    flush_strb |= tag_parity_error_vect;
+    flush_strb |= data_parity_error_vect;
     if (flush_valid_i) flush_strb = '1;
   end
+
+  // Send a warning that an error was detected
+`ifdef TARGET_SIMULATION
+  always @ (posedge clk_i) begin
+    if (tag_parity_error_vect != '0 && data_parity_error_vect != '0)
+      $display("%t [l0cache]: tag and data fault: flushing tags: %b",$time, flush_strb);
+    else if (tag_parity_error_vect != '0)
+      $display("%t [l0cache]: tag fault: flushing tags: %b",$time, flush_strb);
+    else if (data_parity_error_vect != '0)
+      $display("%t [l0cache]: data fault: flushing tags: %b",$time, flush_strb);
+  end
+`endif
 
   // -------------
   // Miss Handling

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -561,6 +561,8 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
     icache_events_o.l0_prefetch = prefetcher_out.vld;
     icache_events_o.l0_double_hit = hit_any & ~hit_early_is_onehot & in_valid_i;
     icache_events_o.l0_stall = !in_ready_o & in_valid_i;
+    icache_events_o.l0_tag_parity_error = in_valid_i & |tag_parity_error_vect;
+    icache_events_o.l0_data_parity_error = in_valid_i & data_parity_error;
   end
 
   // ----------

--- a/src/snitch_icache_pkg.sv
+++ b/src/snitch_icache_pkg.sv
@@ -36,6 +36,7 @@ package snitch_icache_pkg;
     int unsigned FILL_AW;
     int unsigned FILL_DW;
     int unsigned L1_DATA_PARITY_BITS;
+    int unsigned L0_DATA_PARITY_BITS;
     bit L1_TAG_SCM;
     bit EARLY_LATCH;
     bit BUFFER_LOOKUP;

--- a/src/snitch_icache_pkg.sv
+++ b/src/snitch_icache_pkg.sv
@@ -12,6 +12,8 @@ package snitch_icache_pkg;
     logic l0_prefetch;
     logic l0_double_hit;
     logic l0_stall;
+    logic l0_tag_parity_error;
+    logic l0_data_parity_error;
   } icache_l0_events_t;
 
   typedef struct packed {

--- a/test/snitch_icache_l0_tb.sv
+++ b/test/snitch_icache_l0_tb.sv
@@ -87,6 +87,7 @@ module snitch_icache_l0_tb #(
       FETCH_DW:           FETCH_DW,
       FILL_AW:            FILL_AW,
       FILL_DW:            FILL_DW,
+      L0_DATA_PARITY_BITS: 0,
       L1_DATA_PARITY_BITS: 0,
       L1_TAG_SCM:         1'b0,
       EARLY_LATCH:        EARLY_LATCH,


### PR DESCRIPTION
@yvantor

As a side note, this will need additional modifications for snitch compatibility, as an error while the instruction is being fetched will cause a valid to be de-asserted. This is not an issue for the pulp cluster but will be for the snitch cluster.