### PR TITLE
Fix VCS compilation issues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - lookup_serial: Make `write_ready_o` independent of `write_valid_i`.
 - Fix L0 testbench.
-- Remove unnused and duplicate `icache_request` class in `snitch_read_only_cache_tb`, which caused issues when compiling with VCS.
+- Remove unused and duplicate `icache_request` class in `snitch_read_only_cache_tb`, which caused issues when compiling with VCS.
 
 ### Changed
 - Rename `SET_COUNT` to `WAY_COUNT` to correct terminology, as it reflects the number of ways in a set.

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - lookup_serial: Make `write_ready_o` independent of `write_valid_i`.
 - Fix L0 testbench.
+- Remove unnused and duplicate `icache_request` class in `snitch_read_only_cache_tb`, which caused issues when compiling with VCS.
 
 ### Changed
 - Rename `SET_COUNT` to `WAY_COUNT` to correct terminology, as it reflects the number of ways in a set.

--- a/test/snitch_read_only_cache_tb.sv
+++ b/test/snitch_read_only_cache_tb.sv
@@ -5,21 +5,6 @@
 // Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 //         Samuel Riedel <sriedel@iis.ee.ethz.ch>
 
-class icache_request #(
-  parameter int unsigned AddrWidth = 48
-);
-  rand logic [AddrWidth-1:0] addr;
-  rand bit flush;
-
-  constraint flush_c {
-    flush dist { 1 := 2, 0 := 200};
-  }
-
-  constraint addr_c {
-    addr[1:0] == 0;
-  }
-endclass
-
 // Inherit from the random AXI master, but modify the request to emulate a core requesting intstructions.
 class semirand_axi_master #(
   // AXI interface parameters


### PR DESCRIPTION
The `icache_request` class is declared multiple testbenches, which throws errors when compiling with VCS. Since it is not used anywhere in `snitch_read_only_cache_tb`, I removed it from the testbench. If there is use for it in the future, it could also be renamed to fix the naming conflict.