### PR TITLE
treewide: Remove non-resettable FFs

### DIFF
--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -841,8 +841,8 @@ module l0_to_bypass #(
     logic [CFG.FILL_DW-1:0] fill_rsp_data;
     assign fill_rsp_data =
       refill_rsp_data_i >> (in_addr_i[i][CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW);
-    `FFLNR({in_data_o[i], in_error_o[i]}, {fill_rsp_data[CFG.FETCH_DW-1:0], refill_rsp_error_i},
-            rsp_valid[i], clk_i)
+    `FFL({in_data_o[i], in_error_o[i]}, {fill_rsp_data[CFG.FETCH_DW-1:0], refill_rsp_error_i},
+            rsp_valid[i], '0, clk_i, rst_ni)
   end
 
   `FF(state_q, state_d, '{default: Idle})

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -166,7 +166,7 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
       /* verilator lint_on COMBDLY */
       /* verilator lint_on NOLATCH */
     end else begin : gen_ff
-      `FFLNR(data[i], out_rsp_data_i, validate_strb[i], clk_i)
+      `FFL(data[i], out_rsp_data_i, validate_strb[i], '0, clk_i, rst_ni)
     end
   end
 
@@ -239,7 +239,7 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
   assign refill.is_prefetch = 1'b0;
   assign refill_valid = miss;
 
-  `FFLNR(pending_line_refill_q, evict_strb, evict_req, clk_i)
+  `FFL(pending_line_refill_q, evict_strb, evict_req, '0, clk_i, rst_ni)
   `FF(pending_refill_q, pending_refill_d, '0)
 
   always_comb begin


### PR DESCRIPTION
Removes non-resettable FFs from cluster I$, as previously done in https://github.com/pulp-platform/snitch_cluster/pull/154.

I tested this on the post-layout netlist of the Snitch cluster, where there are no more non-resettable FFs after the proposed change.  