### PR TITLE
Exclude TB files from VCS compilation to avoid double class def

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -37,7 +37,7 @@ sources:
   # Level 3
   - src/snitch_icache.sv
   - src/snitch_read_only_cache.sv
-  - target: test
+  - target: all(not(vcs),test)
     files:
       - test/snitch_icache_l0_tb.sv
       - test/snitch_read_only_cache_tb.sv


### PR DESCRIPTION
VCS does not like that the `icache_request` class is defined in both testbenches (even though they are both intended as top-level files and there should never be a clash). As this repo only has a Questa sim flow to begin with, just exclude the testbenches from compilation when using VCS.