### PR TITLE
Linter fixes

### DIFF
--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -868,8 +868,8 @@ module l0_to_bypass #(
       endcase
     end
     logic [CFG.FILL_DW-1:0] fill_rsp_data;
-    assign fill_rsp_data = refill_rsp_data_i >>
-        (in_addr_i[i][CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW);
+    assign fill_rsp_data = CFG.FILL_DW'(refill_rsp_data_i >>
+        (in_addr_i[i][CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW));
     `FFL({in_data_o[i], in_error_o[i]}, {fill_rsp_data[CFG.FETCH_DW-1:0], refill_rsp_error_i},
          rsp_valid[i], '0, clk_i, rst_ni)
   end

--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -250,7 +250,7 @@ module snitch_icache
     ) + 1) {inst_cacheable_i[i]}} & {in_bypass_error[i], in_bypass_data[i]});
 
     // ensure the IDs of responses only have those bits set that are set by the L0 cache that receives them, i.e., bits [2*i+1:2*i]
-    assign masked_local_rsp_id = local_prefetch_rsp.id & ('b11 << (2 * i));
+    assign masked_local_rsp_id = local_prefetch_rsp.id & (2'b11 << (2 * i));
 
     snitch_icache_l0 #(
       .CFG  (CFG),

--- a/src/snitch_icache_handler.sv
+++ b/src/snitch_icache_handler.sv
@@ -110,8 +110,8 @@ module snitch_icache_handler #(
   // the same time, the pop is updated with the push information and the push
   // discarded.
   always_comb begin : p_pushpop_bypass
-    pending_way = push_enable ? 'b1 << push_index : '0;
-    pending_clr = pop_enable ? 'b1 << pop_index : '0;
+    pending_way = CFG.PENDING_COUNT'(push_enable ? 'b1 << push_index : '0);
+    pending_clr = CFG.PENDING_COUNT'(pop_enable ? 'b1 << pop_index : '0);
     pop_addr    = pending_q[pop_index].addr;
     pop_idmask  = pending_q[pop_index].idmask;
     if (push_enable && pop_enable && push_index == pop_index) begin

--- a/src/snitch_icache_handler.sv
+++ b/src/snitch_icache_handler.sv
@@ -110,8 +110,8 @@ module snitch_icache_handler #(
   // the same time, the pop is updated with the push information and the push
   // discarded.
   always_comb begin : p_pushpop_bypass
-    pending_way = CFG.PENDING_COUNT'(push_enable ? 'b1 << push_index : '0);
-    pending_clr = CFG.PENDING_COUNT'(pop_enable ? 'b1 << pop_index : '0);
+    pending_way = CFG.PENDING_COUNT'(push_enable ? 1'b1 << push_index : '0);
+    pending_clr = CFG.PENDING_COUNT'(pop_enable ? 1'b1 << pop_index : '0);
     pop_addr    = pending_q[pop_index].addr;
     pop_idmask  = pending_q[pop_index].idmask;
     if (push_enable && pop_enable && push_index == pop_index) begin

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -105,7 +105,7 @@ module snitch_icache_l0
 
   assign evict_because_miss = miss & ~last_cycle_was_miss_q;
   assign evict_because_prefetch = latch_prefetch & ~last_cycle_was_prefetch_q;
-  assign incoming_rsp_is_prefetch = (out_rsp_id_i == ('b1 << {L0_ID, 1'b1}));
+  assign incoming_rsp_is_prefetch = (out_rsp_id_i == (1'b1 << {L0_ID, 1'b1}));
   // If we get a miss, but there is already a prefetch request in flight for the missed line, simply
   // wait for that prefetch response to come in.
   assign prefetching_missed_line = pending_prefetch_q &
@@ -225,10 +225,10 @@ module snitch_icache_l0
 
     // Round-Robin
     if (evict_req) begin
-      evict_strb = CFG.L0_LINE_COUNT'('b1 << cnt_q);
+      evict_strb = CFG.L0_LINE_COUNT'(1'b1 << cnt_q);
       cnt_d      = cnt_q + 1;
       if (evict_strb == hit_early) begin
-        evict_strb = CFG.L0_LINE_COUNT'('b1 << cnt_d);
+        evict_strb = CFG.L0_LINE_COUNT'(1'b1 << cnt_d);
         cnt_d      = cnt_q + 2;
       end
     end
@@ -299,7 +299,7 @@ module snitch_icache_l0
   assign in_error_o      = '0;
 
   assign out_req_addr_o  = out_req.addr;
-  assign out_req_id_o    = CFG.ID_WIDTH'('b1 << {L0_ID, out_req.is_prefetch});
+  assign out_req_id_o    = CFG.ID_WIDTH'(1'b1 << {L0_ID, out_req.is_prefetch});
 
   // Priority arbitrate requests.
   always_comb begin

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -114,7 +114,7 @@ module snitch_icache_l0
 
   assign evict_req = evict_because_miss | evict_because_prefetch;
 
-  assign addr_tag = in_addr_i >> CFG.LINE_ALIGN;
+  assign addr_tag = CFG.L0_TAG_WIDTH'(in_addr_i >> CFG.LINE_ALIGN);
 
   // ------------
   // Tag Compare
@@ -151,14 +151,13 @@ module snitch_icache_l0
         tag[i].vld <= 0;
         tag[i].tag <= 0;
       end else begin
-        if (evict_strb[i]) begin
+        if (flush_strb[i]) begin
+          tag[i].vld <= 1'b0;
+        end else if (evict_strb[i]) begin
           tag[i].vld <= 1'b0;
           tag[i].tag <= evict_because_prefetch ? addr_tag_prefetch : addr_tag;
         end else if (validate_strb[i]) begin
           tag[i].vld <= 1'b1;
-        end
-        if (flush_strb[i]) begin
-          tag[i].vld <= 1'b0;
         end
       end
     end
@@ -197,7 +196,7 @@ module snitch_icache_l0
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
       ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
     end
-    in_data_o = ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW);
+    in_data_o = CFG.FETCH_DW'(ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW));
   end
 
   // Check whether we had an early multi-hit (e.g., the portion of the tag matched
@@ -224,10 +223,10 @@ module snitch_icache_l0
 
     // Round-Robin
     if (evict_req) begin
-      evict_strb = 1 << cnt_q;
+      evict_strb = CFG.L0_LINE_COUNT'('b1 << cnt_q);
       cnt_d      = cnt_q + 1;
       if (evict_strb == hit_early) begin
-        evict_strb = 1 << cnt_d;
+        evict_strb = CFG.L0_LINE_COUNT'('b1 << cnt_d);
         cnt_d      = cnt_q + 2;
       end
     end
@@ -298,7 +297,7 @@ module snitch_icache_l0
   assign in_error_o      = '0;
 
   assign out_req_addr_o  = out_req.addr;
-  assign out_req_id_o    = 'b1 << {L0_ID, out_req.is_prefetch};
+  assign out_req_id_o    = CFG.ID_WIDTH'('b1 << {L0_ID, out_req.is_prefetch});
 
   // Priority arbitrate requests.
   always_comb begin
@@ -419,7 +418,7 @@ module snitch_icache_l0
   assign prefetcher_out.addr = ($signed(base_addr) + offset) >> CFG.LINE_ALIGN << CFG.LINE_ALIGN;
 
   // check whether cache-line we want to pre-fetch is already present
-  assign addr_tag_prefetch   = prefetcher_out.addr >> CFG.LINE_ALIGN;
+  assign addr_tag_prefetch   = CFG.L0_TAG_WIDTH'(prefetcher_out.addr >> CFG.LINE_ALIGN);
 
   assign latch_prefetch      = prefetcher_out.vld & ~prefetch_req_vld_q;
 
@@ -435,7 +434,7 @@ module snitch_icache_l0
     end
   end
 
-  assign addr_tag_prefetch_req = prefetch_req_addr_q >> CFG.LINE_ALIGN;
+  assign addr_tag_prefetch_req = CFG.L0_TAG_WIDTH'(prefetch_req_addr_q >> CFG.LINE_ALIGN);
   assign prefetch.is_prefetch  = 1'b1;
   assign prefetch.addr         = prefetch_req_addr_q;
   assign prefetch_valid        = prefetch_req_vld_q;

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -151,11 +151,11 @@ module snitch_icache_l0
         tag[i].vld <= 0;
         tag[i].tag <= 0;
       end else begin
-        if (flush_strb[i]) begin
-          tag[i].vld <= 1'b0;
-        end else if (evict_strb[i]) begin
+        if (evict_strb[i]) begin
           tag[i].vld <= 1'b0;
           tag[i].tag <= evict_because_prefetch ? addr_tag_prefetch : addr_tag;
+        end else if (flush_strb[i]) begin
+          tag[i].vld <= 1'b0;
         end else if (validate_strb[i]) begin
           tag[i].vld <= 1'b1;
         end
@@ -196,7 +196,9 @@ module snitch_icache_l0
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
       ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
     end
-    in_data_o = CFG.FETCH_DW'(ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW));
+    in_data_o = CFG.FETCH_DW'(
+      ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW)
+    );
   end
 
   // Check whether we had an early multi-hit (e.g., the portion of the tag matched


### PR DESCRIPTION
Fix multiple issues identified by a linter:
- Flipflop signal is assigned multiple times in an always construct for sequential circuits
- Shift expressions that might cause overflows

This PR has no functional changes.