### PR TITLE
Hook up the error signals in the L0 cache

### DIFF
--- a/src/snitch_icache_handler.sv
+++ b/src/snitch_icache_handler.sv
@@ -315,7 +315,7 @@ module snitch_icache_handler #(
       if (hit_valid) begin
         out_rsp_ready_o = 0;
         in_rsp_data_o   = hit_data;
-        in_rsp_error_o  = 0;
+        in_rsp_error_o  = hit_error;
         in_rsp_id_o     = hit_id;
         in_rsp_valid_o  = 1;
         hit_ready       = in_rsp_ready_i;

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -46,6 +46,7 @@ module snitch_icache_l0
   typedef struct packed {
     logic [CFG.L0_TAG_WIDTH-1:0] tag;
     logic                        vld;
+    logic                        err;
   } tag_t;
 
   logic [CFG.L0_TAG_WIDTH-1:0] addr_tag, addr_tag_prefetch, addr_tag_prefetch_req;
@@ -150,6 +151,7 @@ module snitch_icache_l0
       if (!rst_ni) begin
         tag[i].vld <= 0;
         tag[i].tag <= 0;
+        tag[i].err <= 0;
       end else begin
         if (evict_strb[i]) begin
           tag[i].vld <= 1'b0;
@@ -158,6 +160,7 @@ module snitch_icache_l0
           tag[i].vld <= 1'b0;
         end else if (validate_strb[i]) begin
           tag[i].vld <= 1'b1;
+          tag[i].err <= out_rsp_error_i;
         end
       end
     end
@@ -193,8 +196,10 @@ module snitch_icache_l0
   logic [CFG.LINE_WIDTH-1:0] ins_data;
   always_comb begin : data_muxer
     ins_data = '0;
+    in_error_o = 1'b0;
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
       ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
+      in_error_o |= hit[i] & tag[i].err;
     end
     in_data_o = CFG.FETCH_DW'(
       ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW)
@@ -295,8 +300,6 @@ module snitch_icache_l0
   end
 
   assign out_rsp_ready_o = 1'b1;
-
-  assign in_error_o      = '0;
 
   assign out_req_addr_o  = out_req.addr;
   assign out_req_id_o    = CFG.ID_WIDTH'(1'b1 << {L0_ID, out_req.is_prefetch});


### PR DESCRIPTION
The current implementation of the L0 has an `in_error_o` signal, which is just tied to zero. The error signal provided by the refill/L1 is ignored.
In this PR, the error signal is hooked up in the L0 the same way it is hooked up in the L1.

Changes:
* The icache handler forwards error signals on cache line hits from the L1 to L0.
* The L0 gets an error bit per cache line indicating if an error occured while fetching the cache line (same as in L1).
* On an L0 hit, the error signal is provided together with the data.

