### PR TITLE
Improve latch-based L0 cache for synthesis & physical implementation

### DIFF
--- a/src/snitch_icache_handler.sv
+++ b/src/snitch_icache_handler.sv
@@ -315,7 +315,7 @@ module snitch_icache_handler #(
       if (hit_valid) begin
         out_rsp_ready_o = 0;
         in_rsp_data_o   = hit_data;
-        in_rsp_error_o  = 0;
+        in_rsp_error_o  = hit_error;
         in_rsp_id_o     = hit_id;
         in_rsp_valid_o  = 1;
         hit_ready       = in_rsp_ready_i;

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -145,6 +145,17 @@ module snitch_icache_l0
     .clk_o(clk_inv)
   );
 
+  if (CFG.EARLY_LATCH) begin
+      logic [CFG.LINE_WIDTH-1:0] line_in_q;
+      always_ff @(posedge clk_i, negedge rst_ni) begin
+          if (!rst_ni) begin
+              line_in_q <= '0;
+          end else begin
+              line_in_q <= out_rsp_data_i;
+           end
+       end
+  end
+
   for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_array
     // Tag Array
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -165,10 +176,21 @@ module snitch_icache_l0
       end
     end
     if (CFG.EARLY_LATCH) begin : gen_latch
+
+       logic validate_strb_q;
+
+      always_ff @(posedge clk_i, negedge rst_ni) begin
+          if (!rst_ni) begin
+              validate_strb_q <= '0;
+          end else begin
+              validate_strb_q <= validate_strb[i];
+           end
+       end
+
       logic clk_vld;
       tc_clk_gating i_clk_gate (
-        .clk_i    (clk_inv),
-        .en_i     (validate_strb[i]),
+        .clk_i    (clk_i),
+        .en_i     (validate_strb_q),
         .test_en_i(1'b0),
         .clk_o    (clk_vld)
       );
@@ -177,7 +199,7 @@ module snitch_icache_l0
       /* verilator lint_off COMBDLY */
       always_latch begin
         if (clk_vld) begin
-          data[i] <= out_rsp_data_i;
+          data[i] <= line_in_q;
         end
       end
       /* verilator lint_on COMBDLY */

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -139,14 +139,8 @@ module snitch_icache_l0
   assign hit_prefetch_any = |hit_prefetch;
   assign miss             = ~hit_any & in_valid_i & ~pending_refill_q & ~prefetching_missed_line;
 
-  logic clk_inv;
-  tc_clk_inverter i_clk_inv (
-    .clk_i(clk_i),
-    .clk_o(clk_inv)
-  );
-
+  logic [CFG.LINE_WIDTH-1:0] line_in_q;
   if (CFG.EARLY_LATCH) begin
-      logic [CFG.LINE_WIDTH-1:0] line_in_q;
       always_ff @(posedge clk_i, negedge rst_ni) begin
           if (!rst_ni) begin
               line_in_q <= '0;

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -46,6 +46,7 @@ module snitch_icache_l0
   typedef struct packed {
     logic [CFG.L0_TAG_WIDTH-1:0] tag;
     logic                        vld;
+    logic                        err;
   } tag_t;
 
   logic [CFG.L0_TAG_WIDTH-1:0] addr_tag, addr_tag_prefetch, addr_tag_prefetch_req;
@@ -150,6 +151,7 @@ module snitch_icache_l0
       if (!rst_ni) begin
         tag[i].vld <= 0;
         tag[i].tag <= 0;
+        tag[i].err <= 0;
       end else begin
         if (evict_strb[i]) begin
           tag[i].vld <= 1'b0;
@@ -158,6 +160,7 @@ module snitch_icache_l0
           tag[i].vld <= 1'b0;
         end else if (validate_strb[i]) begin
           tag[i].vld <= 1'b1;
+          tag[i].err <= out_rsp_error_i;
         end
       end
     end
@@ -193,8 +196,10 @@ module snitch_icache_l0
   logic [CFG.LINE_WIDTH-1:0] ins_data;
   always_comb begin : data_muxer
     ins_data = '0;
+    in_error_o = 1'b0;
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
       ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
+      in_error_o |= hit[i] & tag[i].err;
     end
     in_data_o = CFG.FETCH_DW'(
       ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW)
@@ -295,8 +300,6 @@ module snitch_icache_l0
   end
 
   assign out_rsp_ready_o = 1'b1;
-
-  assign in_error_o      = '0;
 
   assign out_req_addr_o  = out_req.addr;
   assign out_req_id_o    = CFG.ID_WIDTH'(1'b1 << {L0_ID, out_req.is_prefetch});

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -12,34 +12,34 @@
 module snitch_icache_l0
   import snitch_icache_pkg::*;
 #(
-  parameter config_t     CFG   = '0,
-  parameter int unsigned L0_ID = 0
+    parameter config_t     CFG   = '0,
+    parameter int unsigned L0_ID = 0
 ) (
-  input logic clk_i,
-  input logic rst_ni,
-  input logic flush_valid_i,
+    input logic clk_i,
+    input logic rst_ni,
+    input logic flush_valid_i,
 
-  input logic enable_prefetching_i,
-  input logic enable_branch_pred_i,
+    input logic enable_prefetching_i,
+    input logic enable_branch_pred_i,
 
-  output icache_l0_events_t icache_events_o,
+    output icache_l0_events_t icache_events_o,
 
-  input  logic [CFG.FETCH_AW-1:0] in_addr_i,
-  input  logic                    in_valid_i,
-  output logic [CFG.FETCH_DW-1:0] in_data_o,
-  output logic                    in_ready_o,
-  output logic                    in_error_o,
+    input  logic [CFG.FETCH_AW-1:0] in_addr_i,
+    input  logic                    in_valid_i,
+    output logic [CFG.FETCH_DW-1:0] in_data_o,
+    output logic                    in_ready_o,
+    output logic                    in_error_o,
 
-  output logic [CFG.FETCH_AW-1:0] out_req_addr_o,
-  output logic [CFG.ID_WIDTH-1:0] out_req_id_o,
-  output logic                    out_req_valid_o,
-  input  logic                    out_req_ready_i,
+    output logic [CFG.FETCH_AW-1:0] out_req_addr_o,
+    output logic [CFG.ID_WIDTH-1:0] out_req_id_o,
+    output logic                    out_req_valid_o,
+    input  logic                    out_req_ready_i,
 
-  input  logic [CFG.LINE_WIDTH-1:0] out_rsp_data_i,
-  input  logic                      out_rsp_error_i,
-  input  logic [  CFG.ID_WIDTH-1:0] out_rsp_id_i,
-  input  logic                      out_rsp_valid_i,
-  output logic                      out_rsp_ready_o
+    input  logic [CFG.LINE_WIDTH-1:0] out_rsp_data_i,
+    input  logic                      out_rsp_error_i,
+    input  logic [  CFG.ID_WIDTH-1:0] out_rsp_id_i,
+    input  logic                      out_rsp_valid_i,
+    output logic                      out_rsp_ready_o
 );
 
   typedef logic [CFG.FETCH_AW-1:0] addr_t;
@@ -141,13 +141,13 @@ module snitch_icache_l0
 
   logic [CFG.LINE_WIDTH-1:0] line_in_q;
   if (CFG.EARLY_LATCH) begin
-      always_ff @(posedge clk_i, negedge rst_ni) begin
-          if (!rst_ni) begin
-              line_in_q <= '0;
-          end else begin
-              line_in_q <= out_rsp_data_i;
-           end
-       end
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (~rst_ni) begin
+        line_in_q <= '0;
+      end else begin
+        line_in_q <= out_rsp_data_i;
+      end
+    end
   end
 
   for (genvar i = 0; i < CFG.L0_LINE_COUNT; i++) begin : gen_array
@@ -171,22 +171,12 @@ module snitch_icache_l0
     end
     if (CFG.EARLY_LATCH) begin : gen_latch
 
-       logic validate_strb_q;
-
-      always_ff @(posedge clk_i, negedge rst_ni) begin
-          if (!rst_ni) begin
-              validate_strb_q <= '0;
-          end else begin
-              validate_strb_q <= validate_strb[i];
-           end
-       end
-
       logic clk_vld;
       tc_clk_gating i_clk_gate (
-        .clk_i    (clk_i),
-        .en_i     (validate_strb_q),
-        .test_en_i(1'b0),
-        .clk_o    (clk_vld)
+          .clk_i    (clk_i),
+          .en_i     (validate_strb[i]),
+          .test_en_i(1'b0),
+          .clk_o    (clk_vld)
       );
       // Data Array
       /* verilator lint_off NOLATCH */
@@ -211,7 +201,7 @@ module snitch_icache_l0
 
   logic [CFG.LINE_WIDTH-1:0] ins_data;
   always_comb begin : data_muxer
-    ins_data = '0;
+    ins_data   = '0;
     in_error_o = 1'b0;
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
       ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
@@ -226,10 +216,10 @@ module snitch_icache_l0
   // multiple entries in the tag array)
   if (CFG.L0_TAG_WIDTH != CFG.L0_EARLY_TAG_WIDTH) begin : gen_multihit_detection
     cc_onehot #(
-      .Width(CFG.L0_LINE_COUNT)
+        .Width(CFG.L0_LINE_COUNT)
     ) i_onehot_hit_early (
-      .d_i        (hit_early),
-      .is_onehot_o(hit_early_is_onehot)
+        .d_i        (hit_early),
+        .is_onehot_o(hit_early_is_onehot)
     );
   end else begin : gen_no_multihit_detection
     assign hit_early_is_onehot = 1'b1;
@@ -388,13 +378,13 @@ module snitch_icache_l0
   assign ins_idx = 32 * taken_idx;
   // Find first taken branch
   lzc #(
-    .WIDTH(FetchPkts),
-    .MODE (0)
+      .WIDTH(FetchPkts),
+      .MODE (0)
   ) i_lzc_branch (
-    // look at branches and jals
-    .in_i   (mask & (is_branch_taken | is_jal)),
-    .cnt_o  (taken_idx),
-    .empty_o(no_prefetch)
+      // look at branches and jals
+      .in_i   (mask & (is_branch_taken | is_jal)),
+      .cnt_o  (taken_idx),
+      .empty_o(no_prefetch)
   );
 
   addr_t base_addr, offset, uj_imm, sb_imm;


### PR DESCRIPTION
This PR changes the latch-based snitch L0 cache implementation which is used when `CFG.EARLY_LATCH` is enabled.
Up to now, the latch-memory often required (practically) infeasible timing constraints. This PR rewrites the latch cache to arrive at virtually the same timing constraints on the setup window as the flip-flop cache while using less area and causing **significantly** less leakage in all reasonable configurations.

The first issue with the current implementation is that it transparent-low latches to replace the posedge-triggered flip-flops used in the FF version of the L0 cache. Since the latches' gate pin is driven by a clock gate, this introduces a non-obvious critical timing condition: Since the latches' gate pin must be stable *before* the negative clock cycle, the clock gate's output must be calculated and latched within **half of a clock cycle** since its inputs (`validate_strb[i]`) depend on posedge-triggered flip flops and module inputs (`out_rsp_id_i`), which in turn depends on checking for a prefetch hit. This can lead to the path becoming critical for the entire cache.

The second issue with the current implementation is that the prefetch/refill path to the L0 storage elements (latches and flipflops) is oftentimes tight if not critical, especially in low-power implementation scenarios where the refilling memory (the L1 cache) has slow (e.g. more than half a clock period) CK -> Q timing. In contrast, the storage elements' read timing is usually much less critical as they are directly fed to a processor core. This forces the implementation to size **all** L0 storage elements accordingly, often leading to significant leakage and increased drive strength "creep" towards the cores.

Both of these issues are addressed in this pull request; instead of using transparent-low latches, the new implementation uses a posedge-triggered write port flip-flop to latch the refill/prefetch line, and selectively updates the new L0 cache which is implemented using transparent-high latches instead. This style of implementation achieves fundamentally the same cycle latency, and only adds the latches' setup and propagation delay to the cache's read path length. In practice, this is close to negligible.

The first issue of having the clock gate in a (sub-)critical path is fixed by the fact that the latches are transparent-high now; this directly implies we can use the whole clock cycle to set up the enable pin. 
The second issue of high drive strength on the main storage elements is mitigated as well. Since the refill/prefetch line is now stored in a write port flip-flop, the latches (being the main storage element) are no longer in a timing-relevant path. 

Since typical implementations use 8 (or more) L0 cache lines, these leakage savings are quite noticeable. In our experiments this change alone has reduced the leakage of **an entire cluster** by over 15% without performance degradation compared to the flip-flop variant. Hold constraints are also no more critical than in the previous implementation as the storage latches hold condition is practically always met (the write port flip flop's output value on changes on a posedge) and next receiving storage element's hold condition edge is typically on the posedge of the next cycle.