### PR TITLE
[CIRCT] Add `minwidth` to ensure endianness and vector width

### DIFF
--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -869,7 +869,7 @@ module l0_to_bypass #(
     end
     logic [CFG.FILL_DW-1:0] fill_rsp_data;
     assign fill_rsp_data = CFG.FILL_DW'(refill_rsp_data_i >>
-        (in_addr_i[i][CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW));
+        (in_addr_i[i][snitch_icache_pkg::minwidth(CFG.LINE_ALIGN,3)-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW));
     `FFL({in_data_o[i], in_error_o[i]}, {fill_rsp_data[CFG.FETCH_DW-1:0], refill_rsp_error_i},
          rsp_valid[i], '0, clk_i, rst_ni)
   end

--- a/src/snitch_icache_handler.sv
+++ b/src/snitch_icache_handler.sv
@@ -6,7 +6,9 @@
 
 `include "common_cells/registers.svh"
 
-module snitch_icache_handler #(
+module snitch_icache_handler
+  import snitch_icache_pkg::*;
+#(
   parameter snitch_icache_pkg::config_t CFG = '0
 ) (
   input logic clk_i,
@@ -278,7 +280,7 @@ module snitch_icache_handler #(
     pop_index       = out_rsp_id_i;
     pop_enable      = 0;
 
-    write_addr_o    = pop_addr[CFG.LINE_ALIGN+:CFG.COUNT_ALIGN];
+    write_addr_o    = pop_addr[CFG.LINE_ALIGN+:minwidth(CFG.COUNT_ALIGN,1)];
     write_way_o     = evict_index;
     write_data_o    = out_rsp_data_i;
     write_tag_o     = pop_addr[CFG.FETCH_AW-1:CFG.LINE_ALIGN+CFG.COUNT_ALIGN];

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -193,16 +193,16 @@ module snitch_icache_l0
   // we hit in the cache and there was a unique hit.
   assign in_ready_o = hit_any;
 
-  logic [CFG.LINE_WIDTH-1:0] ins_data;
+  logic [minwidth(CFG.LINE_WIDTH,32)-1:0] ins_data;
   always_comb begin : data_muxer
     ins_data = '0;
     in_error_o = 1'b0;
     for (int unsigned i = 0; i < CFG.L0_LINE_COUNT; i++) begin
-      ins_data |= {CFG.LINE_WIDTH{hit[i]}} & data[i];
+      ins_data |= {minwidth(CFG.LINE_WIDTH,1){hit[i]}} & data[i];
       in_error_o |= hit[i] & tag[i].err;
     end
     in_data_o = CFG.FETCH_DW'(
-      ins_data >> (in_addr_i[CFG.LINE_ALIGN-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW)
+      ins_data >> (in_addr_i[minwidth(CFG.LINE_ALIGN,3)-1:CFG.FETCH_ALIGN] * CFG.FETCH_DW)
     );
   end
 
@@ -333,7 +333,7 @@ module snitch_icache_l0
   logic [FetchPkts-1:0] is_jal;
   logic [FetchPkts-1:0] mask;
   // make sure that we only look at the packets which are of interest to
-  assign mask = '1 << in_addr_i[CFG.LINE_ALIGN-1:2];
+  assign mask = '1 << in_addr_i[minwidth(CFG.LINE_ALIGN,3)-1:2];
 
   // Instruction aware pre-fetching
   for (genvar i = 0; i < FetchPkts; i++) begin : gen_pre_decode

--- a/src/snitch_icache_lookup_parallel.sv
+++ b/src/snitch_icache_lookup_parallel.sv
@@ -58,8 +58,8 @@ module snitch_icache_lookup_parallel
   // write accesses.
   logic [CFG.COUNT_ALIGN-1:0] ram_addr;
   logic [  CFG.WAY_COUNT-1:0] ram_enable;
-  logic [CFG.LINE_WIDTH-1:0] ram_wdata, ram_rdata[CFG.WAY_COUNT];
-  logic [CFG.TAG_WIDTH+1:0] ram_wtag, ram_rtag[CFG.WAY_COUNT];
+  logic [CFG.LINE_WIDTH-1:0] ram_wdata, ram_rdata[minwidth(CFG.WAY_COUNT, 1)];
+  logic [CFG.TAG_WIDTH+1:0] ram_wtag, ram_rtag[minwidth(CFG.WAY_COUNT, 1)];
   logic                     ram_write;
   logic                     ram_write_q;
   logic [CFG.COUNT_ALIGN:0] init_count_q;
@@ -79,7 +79,7 @@ module snitch_icache_lookup_parallel
     write_ready_o = 0;
     in_ready_o    = 0;
 
-    ram_addr      = in_addr_i[CFG.LINE_ALIGN+:CFG.COUNT_ALIGN];
+    ram_addr      = in_addr_i[CFG.LINE_ALIGN+:minwidth(CFG.COUNT_ALIGN,1)];
     ram_wdata     = write_data_i;
     ram_wtag      = {1'b1, write_error_i, write_tag_i};
     ram_enable    = '0;

--- a/src/snitch_icache_pkg.sv
+++ b/src/snitch_icache_pkg.sv
@@ -6,6 +6,13 @@
 
 package snitch_icache_pkg;
 
+  function automatic int minwidth(int width, int min);
+    if (width >= min) begin
+      return width;
+    end
+    return min;
+  endfunction
+
   typedef struct packed {
     logic l0_miss;
     logic l0_hit;


### PR DESCRIPTION
This PR introduces non-functionally-relevant  RTL changes to allow Slang >= 9 to parse the cache.