### PR TITLE
Fix deadlock condition by disabling prefetches on invalid hits 

### DIFF
--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -71,11 +71,7 @@ module snitch_icache_l0
 
   logic latch_prefetch, last_cycle_was_prefetch_q;
   prefetch_req_t prefetcher_out;
-  // As we have different flipflops (resetable vs non-resetable) we need to
-  // split that struct into two distinct signals to avoid multi-driven warnings
-  // in Verilator.
-  logic prefetch_req_vld_q, prefetch_req_vld_d;
-  logic [CFG.FETCH_AW-1:0] prefetch_req_addr_q, prefetch_req_addr_d;
+  prefetch_req_t prefetch_req_q, prefetch_req_d;
 
   // Holds the onehot signal for the line being refilled at the moment
   logic [CFG.L0_LINE_COUNT-1:0] pending_line_refill_q;
@@ -425,27 +421,25 @@ module snitch_icache_l0
   // check whether cache-line we want to pre-fetch is already present
   assign addr_tag_prefetch   = CFG.L0_TAG_WIDTH'(prefetcher_out.addr >> CFG.LINE_ALIGN);
 
-  assign latch_prefetch      = prefetcher_out.vld & ~prefetch_req_vld_q;
+  assign latch_prefetch      = prefetcher_out.vld & ~prefetch_req_q.vld;
 
   always_comb begin
-    prefetch_req_vld_d  = prefetch_req_vld_q;
-    prefetch_req_addr_d = prefetch_req_addr_q;
+    prefetch_req_d = prefetch_req_q;
 
-    if (prefetch_ready) prefetch_req_vld_d = 1'b0;
+    if (prefetch_ready) prefetch_req_d.vld = 1'b0;
 
     if (latch_prefetch) begin
-      prefetch_req_vld_d  = 1'b1;
-      prefetch_req_addr_d = prefetcher_out.addr;
+      prefetch_req_d.vld  = 1'b1;
+      prefetch_req_d.addr = prefetcher_out.addr;
     end
   end
 
-  assign addr_tag_prefetch_req = CFG.L0_TAG_WIDTH'(prefetch_req_addr_q >> CFG.LINE_ALIGN);
+  assign addr_tag_prefetch_req = CFG.L0_TAG_WIDTH'(prefetch_req_q.addr >> CFG.LINE_ALIGN);
   assign prefetch.is_prefetch  = 1'b1;
-  assign prefetch.addr         = prefetch_req_addr_q;
-  assign prefetch_valid        = prefetch_req_vld_q;
+  assign prefetch.addr         = prefetch_req_q.addr;
+  assign prefetch_valid        = prefetch_req_q.vld;
 
-  `FF(prefetch_req_vld_q, prefetch_req_vld_d, '0)
-  `FF(prefetch_req_addr_q, prefetch_req_addr_d, '0)
+  `FF(prefetch_req_q, prefetch_req_d, '0)
 
   // ------------------
   // Performance Events

--- a/src/snitch_icache_l0.sv
+++ b/src/snitch_icache_l0.sv
@@ -320,7 +320,7 @@ module snitch_icache_l0
   // -------------
   // Generate a prefetch request if the cache hits and we haven't
   // pre-fetched the line yet and there is no other refill in progress.
-  assign prefetcher_out.vld = enable_prefetching_i &
+  assign prefetcher_out.vld = enable_prefetching_i & in_valid_i &
                               hit_any & ~hit_prefetch_any &
                               hit_early_is_onehot & ~pending_prefetch_q;
 


### PR DESCRIPTION
Consider the following scenario, encountered in the Snitch cluster.
All cores reach a barrier except core 0. One would expect all instruction frontends to be idle, except core 0’s, but this is not the case. The L0 cache produces prefetching requests for any address on its request interface, even if valid is low. For some condition I did not have time to fully investigate, but related to a multi-hit scenario, the prefetched cache lines would be flushed immediately after being written back into the cache. Thus, even if the address remains stable on the request interface, the associated prefetching request would not be filtered by the availability of that cache line in the cache, and the same cache line would be repeatedly prefetched over and over again, without end. This causes the L1 cache to be continuously bombarded with prefetching requests from the L0 caches.

Simultaneously, core 0 is doing some useful work, but misses in the L0 cache, causing a refill to be requested from the L1 cache. As prefetch requests have fixed priority over miss requests at the L1 cache, and the other 8 cores are bombarding the L1 cache with prefetching requests, the miss from core 0 never gets served, stalling core 0. As all other cores are waiting on a barrier for core 0, the cycle is closed, and the system deadlocks.

There are several things that one could consider faulty in this whole operation, and which one could fix to solve this specific deadlock condition. For simplicity, I chose to correct the prefetch request filtering logic. I don't believe it's good design to process invalid requests, and the expected behaviour would be that the L0 is idle when the core frontend is idle. It, perhaps accidentally, solves the deadlock since, when the other cores reach the barrier and their frontends become idle, core 0 can resume its execution. A more solid fix would probably also tackle another issue the arbitration priority at the L1 cache, but I don't personally have time to look into this properly, but I opened an issue to track this https://github.com/pulp-platform/cluster_icache/issues/37.

This PR also cleans up an outdated comment after removing non-resettable FFs.