### PR TITLE
Bug fixes: serial-lookup refill collision, SCM tie-off multi-driver, and fetch-merge address mismatch

### DIFF
--- a/src/snitch_icache.sv
+++ b/src/snitch_icache.sv
@@ -469,8 +469,8 @@ module snitch_icache
 
   if (MERGE_FETCHES) begin : gen_merge_fetches
     for (genvar i = 0; i < NR_FETCH_PORTS; i++) begin : gen_prefetch_req_ready
-      assign prefetch_req_ready[i] = prefetch_req_ready_tmp[i] |
-          (prefetch_lookup_req_ready & prefetch_req[i].addr == prefetch_lookup_req.addr);
+      assign prefetch_req_ready[i] = prefetch_lookup_req_ready &
+          (prefetch_req[i].addr == prefetch_lookup_req.addr);
     end
 
     always_comb begin

--- a/src/snitch_icache_lookup_serial.sv
+++ b/src/snitch_icache_lookup_serial.sv
@@ -324,23 +324,25 @@ module snitch_icache_lookup_serial
   // Fall-through buffer the read data: Store the read data if the SRAM bank accepted a request in
   // the previous cycle and if we actually have to buffer them because the receiver is not ready
   `FFL(data_rsp_q, proper_rdata, tag_handshake && !data_ready, '0, clk_i, rst_ni)
-  assign proper_rdata = refill_hit_q && !data_req_q.hit ? refill_wdata_q : data_rdata;
+  // Coincident refill write preempts the data read; serve refill data even on a tag hit.
+  assign proper_rdata = refill_hit_q ? refill_wdata_q : data_rdata;
   assign out_data_o = tag_handshake ? proper_rdata : data_rsp_q;
 
   // Check immediate refill for possible match
   assign refill_hit_d = write_valid_i && write_tag_i == required_tag &&
       write_addr_i == data_req_d.addr[CFG.LINE_ALIGN+:CFG.COUNT_ALIGN];
+  // Bind payload capture to the handshake so a later refill can't overwrite it during a stall.
   `FFL(refill_hit_q, refill_hit_d, tag_valid && tag_ready, '0, clk_i, rst_ni)
-  `FFL(refill_wdata_q, write_data_i, refill_hit_d, '0, clk_i, rst_ni)
-  `FFL(write_way_q, write_way_i, refill_hit_d, '0, clk_i, rst_ni)
-  `FFL(write_error_q, write_error_i, refill_hit_d, '0, clk_i, rst_ni)
+  `FFL(refill_wdata_q, write_data_i, refill_hit_d && tag_valid && tag_ready, '0, clk_i, rst_ni)
+  `FFL(write_way_q, write_way_i, refill_hit_d && tag_valid && tag_ready, '0, clk_i, rst_ni)
+  `FFL(write_error_q, write_error_i, refill_hit_d && tag_valid && tag_ready, '0, clk_i, rst_ni)
 
   // Generate the remaining output signals.
   assign out_addr_o  = data_req_q.addr;
   assign out_id_o    = data_req_q.id;
-  assign out_way_o   = refill_hit_q && !data_req_q.hit ? write_way_q : data_req_q.cway;
+  assign out_way_o   = refill_hit_q ? write_way_q : data_req_q.cway;
   assign out_hit_o   = refill_hit_q || data_req_q.hit;
-  assign out_error_o = refill_hit_q && !data_req_q.hit ? write_error_q : data_req_q.error;
+  assign out_error_o = refill_hit_q ? write_error_q : data_req_q.error;
   assign out_valid_o = data_valid;
   assign data_ready  = out_ready_i;
 

--- a/src/snitch_icache_lookup_serial.sv
+++ b/src/snitch_icache_lookup_serial.sv
@@ -163,9 +163,9 @@ module snitch_icache_lookup_serial
         .WriteAddr  (tag_addr),
         .WriteData  (tag_wdata)
       );
-      assign sram_cfg_out_tag_o = '0;
 
     end
+    assign sram_cfg_out_tag_o = '0;
   end else begin : gen_sram
     logic [CFG.WAY_COUNT*(CFG.TAG_WIDTH+2)-1:0] tag_rdata_flat;
     for (genvar i = 0; i < CFG.WAY_COUNT; i++) begin : g_ways_rdata


### PR DESCRIPTION
## 1. Serial lookup serves stale data on a coincident refill write

When a lookup request reaches the data stage in the same cycle a refill writes its line, the single-port data SRAM prioritises the write and the request's read is preempted, so `data_rdata` holds stale bytes from an earlier read. The output select `refill_hit_q && !data_req_q.hit` trusted that stale read whenever the tag also hit, so the request was served another line's data.

The tag-hit-plus-coincident-refill case is reachable via the two-cycle lookup latency: a request that missed a line before it was cached can still be in flight to the handler when the earlier refill completes and frees its pending/MSHR entry, so a second, redundant refill is issued for the valid line, colliding with a later request that already tag-hits it.

**Fix:**
- Serve the in-flight refill data on any `refill_hit_q` (drop the `!data_req_q.hit` qualifier on `proper_rdata` / `out_way_o` / `out_error_o`).
- Qualify the refill-payload capture (`refill_wdata_q` / `write_way_q` /  `write_error_q`) with the tag handshake (`refill_hit_d && tag_valid && tag_ready`) so a later request's refill cannot overwrite it while the owning request is stalled in the data stage. `out_data_o` is already shielded by the `data_rsp_q` fall-through buffer; this protects the un-buffered way/error outputs.

## 2. Serial SCM tag config tie-off is a multiple driver

In the `gen_scm` (latch-based tag SCM) branch, `assign sram_cfg_out_tag_o = '0;`sat inside the `g_ways` genvar loop, so the output was driven `WAY_COUNT` times.

**Fix:** move the tie-off out of the loop so it is driven exactly once.

## 3. Unexpected fetch merge under address mismatch

In the `MERGE_FETCHES` path, `prefetch_req_ready[i]` OR'd in the arbiter grant `prefetch_req_ready_tmp[i]`, so a fetch port was acknowledged even when a different-address request won the shared lookup mux — that port's prefetch
was consumed without ever being looked up.

**Fix:** gate the ready strictly on an address match with the accepted lookup request, so a port is acknowledged only when its own address is the one being served.